### PR TITLE
Improve error messages

### DIFF
--- a/readconfig.py
+++ b/readconfig.py
@@ -25,17 +25,11 @@ THE SOFTWARE.
 
 import re
 from collections import OrderedDict
+import textwrap
 from typing import Dict
+from colorama import Fore, Back, init
 
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+init() # Colorama auto style reset
 
 def readconfig(fname) -> Dict[str, Dict[str, str]]:
     header_regex = re.compile(r"\[(.+)\]$")
@@ -61,15 +55,14 @@ def readconfig(fname) -> Dict[str, Dict[str, str]]:
             if header_match:
                 currentSectionName = header_match.group(1)
                 if currentSectionName in config:
-                    origin_lineno_length, duplicated_lineno_length = str(header_lineno[currentSectionName]).__len__(), str(lineno).__len__()
-                    currentSectionName_length = currentSectionName.__len__()
-                    raise RuntimeError(
-                        f'''Duplicate header '{currentSectionName}'
-                        {header_lineno[currentSectionName]} | [{currentSectionName}]
-                        {bcolors.FAIL}{" " * (origin_lineno_length + 3)}{"^" * (currentSectionName_length + 2)}{bcolors.ENDC}
-                        {lineno} | [{currentSectionName}]
-                        {bcolors.FAIL}{" " * (duplicated_lineno_length + 3)}{"^" * (currentSectionName_length + 2)}{bcolors.ENDC}''',
-                    )
+                    raise RuntimeError(textwrap.dedent(f'''\
+                        Duplicate header '{currentSectionName}'
+                        {Fore.LIGHTBLACK_EX}{fname}:{lineno}{Fore.RESET}
+
+                        {Fore.RED}>{Fore.RESET} {header_lineno[currentSectionName]} | {Back.RED}[{currentSectionName}]{Back.RESET}
+                        {Fore.RED}>{Fore.RESET} {lineno} | {Back.RED}[{currentSectionName}]{Back.RESET}
+                        ''',
+                    ))
                 currentSection = {}
                 config[currentSectionName] = currentSection
                 header_lineno[currentSectionName] = lineno
@@ -84,16 +77,14 @@ def readconfig(fname) -> Dict[str, Dict[str, str]]:
                 key = key.strip()
                 value = keyvalue_match.group(3)
                 if key in currentSection:
-                    origin_lineno_length, duplicated_lineno_length = str(config_lineno[key]).__len__(), str(lineno).__len__()
-                    current_key_length = key.__len__()
-                    raise RuntimeError(
-                        f'''Duplicate key '{key}'
-                        {config_lineno[key]} | {key} : {currentSection[key]}
-                        {bcolors.FAIL}{" " * (origin_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
-                        {lineno} | {key} : {value}
-                        {bcolors.FAIL}{" " * (duplicated_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
+                    raise RuntimeError(textwrap.dedent(f'''\
+                        Duplicate key '{key}'
+                        {Fore.LIGHTBLACK_EX}{fname}:{lineno}{Fore.RESET}
+                        
+                        {Fore.RED}>{Fore.RESET} {config_lineno[key]} | {Back.RED}{key}{Back.RESET} : {currentSection[key]}
+                        {Fore.RED}>{Fore.RESET} {lineno} | {Back.RED}{key}{Back.RESET} : {value}
                         '''
-                    )
+                    ))
                 currentSection[key] = value
                 config_lineno[key] = lineno
                 continue
@@ -107,16 +98,14 @@ def readconfig(fname) -> Dict[str, Dict[str, str]]:
                 key = key.replace("\\=", "=")
                 key = key.strip()
                 if key in currentSection:
-                    origin_lineno_length, duplicated_lineno_length = str(config_lineno[key]).__len__(), str(lineno).__len__()
-                    current_key_length = key.__len__()
-                    raise RuntimeError(
-                        f'''Duplicate key '{key}' in '{currentSectionName}'
-                        {config_lineno[key]} | {key} : {currentSection[key]}
-                        {bcolors.FAIL}{" " * (origin_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
-                        {lineno} | {key}
-                        {bcolors.FAIL}{" " * (duplicated_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
+                    raise RuntimeError(textwrap.dedent(f'''\
+                        Duplicate key '{key}' in '{currentSectionName}'
+                        {Fore.LIGHTBLACK_EX}{fname}:{lineno}{Fore.RESET}
+                        
+                        {Fore.RED}>{Fore.RESET} {config_lineno[key]} | {Back.RED}{key}{Back.RESET} : {currentSection[key]}
+                        {Fore.RED}>{Fore.RESET} {lineno} | {Back.RED}{key}{Back.RESET}
                         '''
-                    )
+                    ))
                 currentSection[key] = ""
                 config_lineno[key] = lineno
                 continue

--- a/readconfig.py
+++ b/readconfig.py
@@ -27,6 +27,15 @@ import re
 from collections import OrderedDict
 from typing import Dict
 
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
 
 def readconfig(fname) -> Dict[str, Dict[str, str]]:
     header_regex = re.compile(r"\[(.+)\]$")
@@ -52,11 +61,14 @@ def readconfig(fname) -> Dict[str, Dict[str, str]]:
             if header_match:
                 currentSectionName = header_match.group(1)
                 if currentSectionName in config:
+                    origin_lineno_length, duplicated_lineno_length = str(header_lineno[currentSectionName]).__len__(), str(lineno).__len__()
+                    currentSectionName_length = currentSectionName.__len__()
                     raise RuntimeError(
-                        "Duplicate header [%s]" % currentSectionName,
-                        "[Line %u] [%s]"
-                        % (header_lineno[currentSectionName], currentSectionName),
-                        "[Line %u] [%s]" % (lineno, currentSectionName),
+                        f'''Duplicate header '{currentSectionName}'
+                        {header_lineno[currentSectionName]} | [{currentSectionName}]
+                        {bcolors.FAIL}{" " * (origin_lineno_length + 3)}{"^" * (currentSectionName_length + 2)}{bcolors.ENDC}
+                        {lineno} | [{currentSectionName}]
+                        {bcolors.FAIL}{" " * (duplicated_lineno_length + 3)}{"^" * (currentSectionName_length + 2)}{bcolors.ENDC}''',
                     )
                 currentSection = {}
                 config[currentSectionName] = currentSection
@@ -72,11 +84,15 @@ def readconfig(fname) -> Dict[str, Dict[str, str]]:
                 key = key.strip()
                 value = keyvalue_match.group(3)
                 if key in currentSection:
+                    origin_lineno_length, duplicated_lineno_length = str(config_lineno[key]).__len__(), str(lineno).__len__()
+                    current_key_length = key.__len__()
                     raise RuntimeError(
-                        "Duplicate key %s" % key,
-                        "[Line %u] %s : %s"
-                        % (config_lineno[key], key, currentSection[key]),
-                        "[Line %u] %s : %s" % (lineno, key, value),
+                        f'''Duplicate key '{key}'
+                        {config_lineno[key]} | {key} : {currentSection[key]}
+                        {bcolors.FAIL}{" " * (origin_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
+                        {lineno} | {key} : {value}
+                        {bcolors.FAIL}{" " * (duplicated_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
+                        '''
                     )
                 currentSection[key] = value
                 config_lineno[key] = lineno
@@ -91,11 +107,15 @@ def readconfig(fname) -> Dict[str, Dict[str, str]]:
                 key = key.replace("\\=", "=")
                 key = key.strip()
                 if key in currentSection:
+                    origin_lineno_length, duplicated_lineno_length = str(config_lineno[key]).__len__(), str(lineno).__len__()
+                    current_key_length = key.__len__()
                     raise RuntimeError(
-                        "Duplicate key %s in [%s]" % (key, currentSectionName),
-                        "[Line %u] %s : %s"
-                        % (config_lineno[key], key, currentSection[key]),
-                        "[Line %u] %s" % (lineno, key),
+                        f'''Duplicate key '{key}' in '{currentSectionName}'
+                        {config_lineno[key]} | {key} : {currentSection[key]}
+                        {bcolors.FAIL}{" " * (origin_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
+                        {lineno} | {key}
+                        {bcolors.FAIL}{" " * (duplicated_lineno_length + 3)}{"^" * current_key_length}{bcolors.ENDC}
+                        '''
                     )
                 currentSection[key] = ""
                 config_lineno[key] = lineno


### PR DESCRIPTION
This changes `RuntimeError` messages to print looks like actual codes. See #54

examples:
1. Duplicate Section
<img width="199" alt="image" src="https://user-images.githubusercontent.com/36349353/163256228-8f809446-3a97-4ef0-8b0c-55e84e26eee9.png">
<img width="851" alt="image" src="https://user-images.githubusercontent.com/36349353/163256169-fc7565aa-a32b-4a30-8593-aa75b073b24f.png">

2. Duplicate Key

<img width="185" alt="image" src="https://user-images.githubusercontent.com/36349353/163255992-439f93cc-6d95-4872-8c3e-63f211471f42.png">
<img width="856" alt="image" src="https://user-images.githubusercontent.com/36349353/163255812-514166c6-6e41-412d-87fe-5a7d8d4f323b.png">
